### PR TITLE
Pass `engines` through Packtory config

### DIFF
--- a/packtory.config.js
+++ b/packtory.config.js
@@ -78,7 +78,8 @@ export async function buildConfig() {
             additionalPackageJsonAttributes: {
                 author: packageJson.author,
                 license: packageJson.license,
-                repository: packageJson.repository
+                repository: packageJson.repository,
+                engines: packageJson.engines
             },
             additionalFiles: [
                 {


### PR DESCRIPTION
Published packages should retain the root package runtime constraints. This passes `package.json` `engines` through the shared Packtory metadata so generated package manifests include the same Node support range.