### PR TITLE
Use shared `renovate-config` preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>enormora/renovate-config#1.0.0",
-    "github>enormora/renovate-config:github-automerge#1.0.0"
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "github>enormora/renovate-config#1.0.0",
+        "github>enormora/renovate-config:github-automerge#1.0.0"
+    ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,7 @@
 {
-    "lockFileMaintenance": {
-        "enabled": true,
-        "automerge": true
-    },
-    "packageRules": [
-        {
-            "matchDepTypes": [
-                "dependencies",
-                "devDependencies"
-            ],
-            "matchUpdateTypes": [
-                "minor",
-                "patch"
-            ],
-            "automerge": true,
-            "automergeType": "branch"
-        }
-    ],
-    "platformAutomerge": true,
-    "automergeStrategy": "merge-commit"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>enormora/renovate-config#1.0.0",
+    "github>enormora/renovate-config:github-automerge#1.0.0"
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,4 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "github>enormora/renovate-config#1.0.0",
-        "github>enormora/renovate-config:github-automerge#1.0.0"
-    ]
+    "extends": ["github>enormora/renovate-config#1.0.0", "github>enormora/renovate-config:github-automerge#1.0.0"]
 }


### PR DESCRIPTION
This switches Renovate to the shared Enormora preset repository and leaves local exceptions in this repository configuration.

The automerge preset follows the branch rules in this repository.